### PR TITLE
Fix the package.json entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,17 +2,17 @@
   "name": "inuit-clearfix",
   "version": "0.2.1",
   "description": "Small clearfixing utility for the inuitcss framework",
-  "main": "_generic.clearfix.scss",
+  "main": "_trumps.clearfix.scss",
   "repository": {
     "type": "git",
-    "url": "https://github.com/inuitcss/generic.clearfix.git"
+    "url": "https://github.com/inuitcss/trumps.clearfix.git"
   },
   "author": "Harry Roberts <harry@csswizardry.com>",
   "license": "Apache 2",
   "bugs": {
-    "url": "https://github.com/inuitcss/generic.clearfix/issues"
+    "url": "https://github.com/inuitcss/trumps.clearfix/issues"
   },
-  "homepage": "https://github.com/inuitcss/generic.clearfix",
+  "homepage": "https://github.com/inuitcss/trumps.clearfix",
   "keywords": [
     "inuitcss",
     "oocss",


### PR DESCRIPTION
It was still pointing to the old `_generic` namespace.
